### PR TITLE
(handler): Custom `web` framework to handle routes

### DIFF
--- a/app/app-api/handlers/check.go
+++ b/app/app-api/handlers/check.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -10,12 +11,13 @@ type check struct {
 	log *log.Logger
 }
 
-func (c check) readiness(w http.ResponseWriter, r *http.Request) {
+func (c check) readiness(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	status := struct {
 		Status string
 	}{
 		Status: "Ok",
 	}
-	json.NewEncoder(w).Encode(status)
 	log.Println(r, status)
+	return json.NewEncoder(w).Encode(status)
+
 }

--- a/app/app-api/handlers/handlers.go
+++ b/app/app-api/handlers/handlers.go
@@ -1,21 +1,22 @@
 package handlers
 
 import (
-	"github.com/dimfeld/httptreemux/v5"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/bencodesall/ardanlabs-service-2.0/foundation/web"
 )
 
 // API constructs an http.Handler with all application routes defined
-func API(build string, shutdown chan os.Signal, log *log.Logger) *httptreemux.ContextMux {
+func API(build string, shutdown chan os.Signal, log *log.Logger) *web.App {
 
-	tm := httptreemux.NewContextMux()
+	app := web.NewApp(shutdown)
 
 	check := check{
 		log: log,
 	}
-	tm.Handle(http.MethodGet, "/test", check.readiness)
+	app.Handle(http.MethodGet, "/readiness", check.readiness)
 
-	return tm
+	return app
 }

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"syscall"
+
+	"github.com/dimfeld/httptreemux/v5"
+)
+
+// Handler is a type that handles an http request within our own mini framework
+// using an "onion" method
+type Handler func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+
+// App is the entrypoint into our applicatino and what configures our context
+// object for each of our http handlers. Feel free to add any configuration
+// data/logic on this App struct. App is everything that a ContextMux is by
+// virtue of promotion.
+type App struct {
+	*httptreemux.ContextMux
+	shutdown chan os.Signal
+}
+
+// NewApp creates an App value that handles a set of routes for the application.
+func NewApp(shutdown chan os.Signal) *App {
+	app := App{
+		ContextMux: httptreemux.NewContextMux(),
+		shutdown:   shutdown,
+	}
+
+	return &app
+}
+
+// SignalShutdown is used to gracefully shutdown the app when an integrity
+// issue is identified.
+func (a *App) SignalShutdown() {
+	a.shutdown <- syscall.SIGTERM
+}
+
+// Handle ...
+func (a *App) Handle(method string, path string, handler Handler) {
+	h := func(w http.ResponseWriter, r *http.Request) {
+
+		// BOILERPLATE
+
+		if err := handler(r.Context(), w, r); err != nil {
+			a.SignalShutdown()
+			return
+		}
+
+		// BOILERPLATE
+	}
+	a.ContextMux.Handle(method, path, h)
+}


### PR DESCRIPTION
To faclitate the returning of errors at the handler-level (precision semantics), the `*httptreemux.ContextMux` is embeded into a custom struct called `App`.  The custom "framework" provides `App` as everything that `httptreemux.ContextMux` by virtue of type promotion through embedding.

- `foundation/web` package
  - `web.Handler` (function) type facilitates the passing of `context.Context` and the returning of an error. *NOTE: `Handler` functions are defined in the `handlers` package and may or not require logging or various trace/telemetry info according to architecture decisions for the specific handler/route being considered.*
  - `web.App` struct embeds `*httptreemux.ContextMux` and composes a `chan` for shutdown signalling.
  - Factory function `web.NewApp()` used to “extend” the use of default `httpServe` from `httptreemux.ContextMux` with custom boilerplate code
  - `*App.SignalShutdown()` passes a value into the `App` structs shutdown channel variable to handle integrity issues gracefully.
  - `*App.Handle()` receives a custom handler function which gets wrapped by an internal func variable to be passed passed down to the embedded `ContextMux.Handle()` function as the required `Handle` signature required by serveHTTP.

- Application specific `handlers` packages
  - `handlers.go` specifies the route handlers for the "application specific" routes. In this case `app-api`.
  - `check.go` specifies a struct,  `check`, for embedding the concrete logger, and a handler for the `/rediness` route defined in the `API()` function.

TODO: Lot's of things to be expanded upon, but this is a good base to allow for context configuration, logging, tracing, and other concerns at the individual route level (precision-based semantics)
  - `ctx` argument is unused in `(check) readiness`
  - `build` argument is unused in `handlers.API`

[learngo-1]